### PR TITLE
feat: asynchronsing file read in workflow

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,12 +3,13 @@ import { readFileSync } from 'fs';
 import { isEmpty } from 'lodash';
 import jsonata from 'jsonata';
 import { SimpleStep, Step, WorkflowStep, Workflow } from './types';
+import { readFile } from 'fs/promises';
 
 export class WorkflowUtils {
   // Ref: https://github.com/rudderlabs/rudder-transformer-cdk/pull/50#discussion_r882441319
   // TODO: should we make this async ? & also remove the above comment
-  static createFromFilePath(workflowYamlPath: string): Workflow {
-    const workflowYaml = readFileSync(workflowYamlPath, { encoding: 'utf-8' });
+  static async createFromFilePath(workflowYamlPath: string): Promise<Workflow> {
+    const workflowYaml = await readFile(workflowYamlPath, { encoding: 'utf-8' });
     return yaml.load(workflowYaml) as Workflow;
   }
 


### PR DESCRIPTION
Signed-off-by: Sai Sankeerth <sanpj2292@github.com>

## Description of the change

Through this PR, we are trying to asynchronise the workflow file read

A sample implementation in `rudder-transformer` would look like this:

```javascript
// rudder-transformer/v0/destinations/pinterest_tag/index.js
const { join } = require("path");
const { WorkflowUtils, WorkflowEngine } = require("rudder-workflow-engine");

// const { V2 } = require("rudder-transformer-cdk");
// const singleWorkflow = V2.WorkflowUtils.createFromFilePath(
//   join(__dirname, "pinterest_tag_single_workflow.yaml")
// );
// const singleWorkflowEngine = new V2.WorkflowEngine(singleWorkflow, __dirname);
// exports.singleWorkflowEngine = singleWorkflowEngine;
// const batchWorkflow = V2.WorkflowUtils.createFromFilePath(
//   join(__dirname, "pinterest_tag_batch_workflow.yaml")
// );
// const batchWorkflowEngine = new V2.WorkflowEngine(batchWorkflow, __dirname);
// exports.batchWorkflowEngine = batchWorkflowEngine;
module.exports = {
  importFuncs: async () => {
    // some async initiallizers
    const singleWorkflow = await WorkflowUtils.createFromFilePath(
      join(__dirname, "pinterest_tag_single_workflow.yaml")
    );
    const singleWorkflowEngine = new WorkflowEngine(singleWorkflow, __dirname);
    await singleWorkflowEngine.init();

    const batchWorkflow = await WorkflowUtils.createFromFilePath(
      join(__dirname, "pinterest_tag_batch_workflow.yaml")
    );
    const batchWorkflowEngine = new WorkflowEngine(batchWorkflow, __dirname);
    await batchWorkflowEngine.init();
    // resolve the export promise
    return {
      singleWorkflowEngine,
      batchWorkflowEngine
    };
  }
};
```

This is how the test file would look like
```javascript
const integration = "pinterest_tag";
const name = "Pinterest Conversion API";

const fs = require("fs");
const path = require("path");
const version = "v0";

const inputDataFile = fs.readFileSync(
  path.resolve(__dirname, `./data/${integration}_input.json`)
);
const outputDataFile = fs.readFileSync(
  path.resolve(__dirname, `./data/${integration}_output.json`)
);
const inputData = JSON.parse(inputDataFile);
const expectedData = JSON.parse(outputDataFile);

// Router Test Data
const inputRouterDataFile = fs.readFileSync(
  path.resolve(__dirname, `./data/${integration}_router_input.json`)
);
const outputRouterDataFile = fs.readFileSync(
  path.resolve(__dirname, `./data/${integration}_router_output.json`)
);
const inputRouterData = JSON.parse(inputRouterDataFile);
const expectedRouterData = JSON.parse(outputRouterDataFile);

describe(`${name} Tests`, () => {
  let workflowEng;
  beforeAll(async () => {
    const {
      importFuncs
    } = require(`../${version}/destinations/${integration}/index`);
    workflowEng = await importFuncs();
    return workflowEng;
  });
  describe("Processor Tests", () => {
    inputData.forEach((input, index) => {
      it(`${name} - payload: ${index}`, async () => {
        const expected = expectedData[index];
        try {
          const result = await workflowEng.singleWorkflowEngine.execute(input);
          expect(JSON.parse(JSON.stringify(result.output))).toEqual(expected);
        } catch (error) {
          expect(error.message).toEqual(expected.error);
        }
      });
    });
  });
  describe("Router Tests", () => {
    it("Payload", async () => {
      const result = await workflowEng.batchWorkflowEngine.execute(inputRouterData);
      expect(JSON.parse(JSON.stringify(result.output))).toEqual(
        expectedRouterData
      );
    });
  });
});

```


## Problems
- The importing of each of the transformation code in `versionedRouter.js` is not very straightforward. Although tests we had something like a `beforeAll` with async call back support, using which we could write the test-cases
- We'd have to write async logic even while exporting the workflowEngine for each of the destinations. Makes it a bit hard to understand


## Checklists

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
