### PR TITLE
fix: jsonata output clean up

### DIFF
--- a/src/workflow/utils.ts
+++ b/src/workflow/utils.ts
@@ -92,6 +92,22 @@ export class WorkflowUtils {
     return error.response?.status || error.status || 500;
   }
 
+  /**
+   * JSONata adds custom properties to arrays for internal processing
+   * hence it fails the comparison so we need to cleanup.
+   * Reference: https://github.com/jsonata-js/jsonata/issues/296
+   */
+  private static cleanUpArrays(obj: any) {
+    if (Array.isArray(obj)) {
+      obj = obj.map(WorkflowUtils.cleanUpArrays);
+    } else if (obj instanceof Object) {
+      Object.keys(obj).forEach((key) => {
+        obj[key] = WorkflowUtils.cleanUpArrays(obj[key]);
+      });
+    }
+    return obj;
+  }
+
   static evaluateJsonataExpr(
     expr: jsonata.Expression,
     data: any,
@@ -110,6 +126,6 @@ export class WorkflowUtils {
         }
         resolve(response);
       });
-    });
+    }).then(WorkflowUtils.cleanUpArrays);
   }
 }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -29,8 +29,13 @@ function testLogger(logger: LogCounts) {
   expect(fakeLogger.error.mock.calls.length).toBeGreaterThanOrEqual(errorCount);
 }
 
-function getErrorMatcher(error: SceanarioError = {}) {
-  let errorMatcher = error as any;
+function getErrorMatcher(error?: SceanarioError) {
+  if (!error) {
+    // Ideally shouldn't reach here.
+    // Sending default error so that test case fails.
+    return { message: 'should fail' };
+  }
+  let errorMatcher = error;
   if (error.message) {
     errorMatcher.message = expect.stringContaining(error.message);
   }
@@ -53,7 +58,6 @@ describe('Scenarios tests', () => {
             const result = await SceanarioUtils.executeScenario(workflowEngine, scenario);
             expect(result.output).toEqual(scenario.output);
           } catch (error: any) {
-            expect(scenario.error).toBeDefined();
             expect(error).toMatchObject(getErrorMatcher(scenario.error));
             if (scenario.errorClass) {
               expect(error.error?.constructor.name).toEqual(scenario.errorClass);

--- a/test/utils/scenario.ts
+++ b/test/utils/scenario.ts
@@ -15,9 +15,6 @@ export class SceanarioUtils {
 
   private static async execute(executor: Executor, input: any): Promise<any> {
     let result = await executor.execute(input);
-    // JSONata creates immutable arrays and it cause issues
-    // so doing the following makes the comparison successful.
-    result = JSON.parse(JSON.stringify(result));
     return { output: result.output };
   }
 


### PR DESCRIPTION
## Description of the change

JSONata adds custom properties to arrays for internal processing hence it fails the comparison so we need to cleanup.
Reference: https://github.com/jsonata-js/jsonata/issues/296
## Checklists

### Development

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
