### PR TITLE
fix: print error step log

### DIFF
--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -61,8 +61,9 @@ export class WorkflowEngine implements Executor {
           break;
         }
       } catch (error) {
+        logger.error(`step: ${step.name} failed with error:`);
         if (step.onError === StepExitAction.Continue) {
-          logger.info(`step: ${step.name} failed`, error);
+          logger.error(error);
           continue;
         }
         this.handleError(error, step.name);


### PR DESCRIPTION
## Description of the change

Currently when unhandled `TypeError` is thrown the step name where the error occurred is not showing up. Through this PR we are trying to print error step log.

This came up as a result of the below mentioned bugsnag issue
https://app.squadcast.com/incident/64962468d21ded740b76fb76

### Development

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
