### PR TITLE
feat: add binding for contains all and add test cases

### DIFF
--- a/src/__tests__/bindings/common.tests.ts
+++ b/src/__tests__/bindings/common.tests.ts
@@ -1,4 +1,4 @@
-import { toMilliseconds, toSeconds, toArray, SHA256 } from '../../bindings';
+import { toMilliseconds, toSeconds, toArray, SHA256, containsAll } from '../../bindings';
 
 describe('Common Bindings', () => {
   describe('toMilliseconds', () => {
@@ -43,6 +43,24 @@ describe('Common Bindings', () => {
     });
     it('should return undefined if input is undefined', () => {
       expect(SHA256(undefined)).toEqual(undefined);
+    });
+  });
+
+  describe('containsAll', () => {
+    it('should return true if array2 contains all of array1', () => {
+      expect(containsAll(['pizza', 'cola'], ['pizza', 'cake', 'cola'])).toEqual(true);
+    });
+    it('should return false if array2 does not contain all of array1', () => {
+      expect(containsAll(['pizza', 'cola', 'cheese'], ['pizza', 'cake', 'cola'])).toEqual(false);
+    });
+    it('should return true if array1 is empty array', () => {
+      expect(containsAll([], ['pizza', 'cake', 'cola'])).toEqual(true);
+    });
+    it('should return false if array2 empty array', () => {
+      expect(containsAll(['pizza', 'cola', 'cheese'], [])).toEqual(false);
+    });
+    it('should return true if both array1 and array2 empty array', () => {
+      expect(containsAll([], [])).toEqual(true);
     });
   });
 });

--- a/src/bindings/common.ts
+++ b/src/bindings/common.ts
@@ -69,6 +69,7 @@ export function SHA256(text: string | number | undefined) {
   return result;
 }
 
+// Check if arr1 is subset of arr2
 export function containsAll(arr1: any[], arr2: any[]): boolean {
   return arr1.every((element) => {
     return arr2.includes(element);

--- a/src/bindings/common.ts
+++ b/src/bindings/common.ts
@@ -68,3 +68,9 @@ export function SHA256(text: string | number | undefined) {
   const result = Buffer.from(digest).toString('hex');
   return result;
 }
+
+export function containsAll(arr1: any[], arr2: any[]): boolean {
+  return arr1.every((element) => {
+    return arr2.includes(element);
+  });
+}


### PR DESCRIPTION
## Description of the change

adding binding for `containsAll` function, which is to check if array2 contains all the elements of array1

## Checklists

### Development

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
