### PR TITLE
feat(INT-341): add support for passing custom workflow executor

### DIFF
--- a/src/workflow/default_executor.ts
+++ b/src/workflow/default_executor.ts
@@ -1,0 +1,56 @@
+import { StepExitAction } from '../steps/types';
+import { ErrorUtils, logger } from '../common';
+import { WorkflowExecutionError } from './errors';
+import { ExecutionBindings, WorkflowExecutor, WorkflowOutput } from './types';
+import { WorkflowEngine } from './engine';
+
+export class DefaultWorkflowExecutor implements WorkflowExecutor {
+  static readonly INSTANCE = new DefaultWorkflowExecutor();
+  async execute(engine: WorkflowEngine, input: any): Promise<WorkflowOutput> {
+    const context = {};
+    const executionBindings: ExecutionBindings = {
+      ...engine.bindings,
+      outputs: {},
+      context,
+      setContext: (key, value) => {
+        context[key] = value;
+      },
+    };
+
+    let finalOutput: any;
+    for (const stepExecutor of engine.stepExecutors) {
+      const step = stepExecutor.getStep();
+      try {
+        const { skipped, output } = await stepExecutor.execute(input, executionBindings);
+        if (skipped) {
+          continue;
+        }
+        executionBindings.outputs[step.name] = output;
+        finalOutput = output;
+        if (step.onComplete === StepExitAction.Return) {
+          break;
+        }
+      } catch (error) {
+        logger.error(`step: ${step.name} failed with error:`);
+        if (step.onError === StepExitAction.Continue) {
+          logger.error(error);
+          continue;
+        }
+        this.handleError(error, engine.name, step.name);
+      }
+    }
+
+    return { output: finalOutput, outputs: executionBindings.outputs };
+  }
+
+  handleError(error: any, workflowName: string, stepName: string) {
+    throw new WorkflowExecutionError(
+      error.message,
+      ErrorUtils.getErrorStatus(error),
+      workflowName,
+      stepName,
+      error.childStepName,
+      error.error,
+    );
+  }
+}

--- a/src/workflow/factory.ts
+++ b/src/workflow/factory.ts
@@ -5,6 +5,7 @@ import { StepCreationError } from '../steps/errors';
 import { WorkflowEngine } from './engine';
 import { Step, StepExecutor, StepExecutorFactory, StepType, StepUtils } from '../steps';
 import { Binding, Workflow, WorkflowOptions, WorkflowOptionsInternal } from './types';
+import { DefaultWorkflowExecutor } from './default_executor';
 
 export class WorkflowEngineFactory {
   private static prepareWorkflow(workflow: Workflow, options: WorkflowOptions) {
@@ -21,7 +22,12 @@ export class WorkflowEngineFactory {
       const bindings = await this.prepareBindings(workflow.bindings || [], optionsInteranl);
       optionsInteranl.currentBindings = bindings;
       const stepExecutors = await this.createStepExecutors(workflow.steps, optionsInteranl);
-      return new WorkflowEngine(workflow.name, bindings, stepExecutors);
+      return new WorkflowEngine(
+        workflow.name,
+        options.executor || DefaultWorkflowExecutor.INSTANCE,
+        bindings,
+        stepExecutors,
+      );
     } catch (error: any) {
       if (error instanceof WorkflowCreationError) {
         throw error;

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -1,4 +1,6 @@
+import { Executor } from '../common';
 import { Step, TemplateType } from '../steps/types';
+import { WorkflowEngine } from './engine';
 
 export type PathBinding = {
   // exported value's name in bindings
@@ -50,9 +52,14 @@ export type WorkflowOptions = {
   rootPath: string;
   creationTimeBindings?: Record<string, any>;
   templateType?: TemplateType;
+  executor?: WorkflowExecutor;
 };
 
 export type WorkflowOptionsInternal = WorkflowOptions & {
   currentBindings: Record<string, any>;
   parentBindings?: Record<string, any>;
 };
+
+export interface WorkflowExecutor {
+  execute(engine: WorkflowEngine, input: any): Promise<WorkflowOutput>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     "declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
     "declarationMap": true /* Create sourcemaps for d.ts files. */,
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
## Description of the change

We want to implement custom workflow executor for rudder-transformer so I have added support to override the default workflow executor.

## Checklists

### Development

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
