### PR TITLE
chore: remove support for getting child step executor

### DIFF
--- a/src/steps/base/executors/base.ts
+++ b/src/steps/base/executors/base.ts
@@ -15,9 +15,5 @@ export abstract class BaseStepExecutor implements StepExecutor {
     return this.step.name;
   }
 
-  getBaseExecutor(): BaseStepExecutor {
-    return this;
-  }
-
   abstract execute(input: any, executionBindings: ExecutionBindings): Promise<StepOutput>;
 }

--- a/src/steps/base/executors/workflow_step.ts
+++ b/src/steps/base/executors/workflow_step.ts
@@ -10,16 +10,6 @@ export class WorkflowStepExecutor extends BaseStepExecutor {
     this.stepExecutors = stepExecutors;
   }
 
-  getStepExecutor(childStepName: string): StepExecutor {
-    const stepExecutor = this.stepExecutors.find(
-      (stepExecutor) => stepExecutor.getStepName() === childStepName,
-    );
-    if (!stepExecutor) {
-      throw new Error(`${this.getStepName()}:${childStepName} was not found`);
-    }
-    return stepExecutor;
-  }
-
   async executeChildStep(
     childExector: StepExecutor,
     input: any,

--- a/src/steps/composed/executors/composable.ts
+++ b/src/steps/composed/executors/composable.ts
@@ -1,5 +1,4 @@
 import { ExecutionBindings } from '../../../workflow/types';
-import { BaseStepExecutor } from '../../base';
 import { Step, StepExecutor, StepOutput } from '../../types';
 
 /**
@@ -19,10 +18,6 @@ export class ComposableStepExecutor implements StepExecutor {
 
   getStepName(): string {
     return this.stepExecutor.getStepName();
-  }
-
-  getBaseExecutor(): BaseStepExecutor {
-    return this.stepExecutor.getBaseExecutor();
   }
 
   execute(input: any, executionBindings: ExecutionBindings): Promise<StepOutput> {

--- a/src/steps/types.ts
+++ b/src/steps/types.ts
@@ -1,6 +1,5 @@
 import { ExecutionBindings, Binding } from '../workflow/types';
 import { Executor } from '../common/types';
-import { BaseStepExecutor } from './base';
 import { JsonataStepExecutor, JsonTemplateStepExecutor } from './base/simple/executors/template';
 
 export interface StepExecutor extends Executor {
@@ -12,10 +11,6 @@ export interface StepExecutor extends Executor {
    * Returns the step which executor is operating
    */
   getStep(): Step;
-  /**
-   * Return the base step executor
-   */
-  getBaseExecutor(): BaseStepExecutor;
   /**
    * Executes the step
    */

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -21,21 +21,13 @@ export class WorkflowEngine implements Executor {
     this.executor = executor;
   }
 
-  getStepExecutor(stepName: string, childStepName?: string): StepExecutor {
+  getStepExecutor(stepName: string): StepExecutor {
     let stepExecutor = this.stepExecutors.find(
       (stepExecutor) => stepExecutor.getStepName() === stepName,
     );
 
     if (!stepExecutor) {
       throw new Error(`${stepName} was not found`);
-    }
-
-    if (childStepName) {
-      const baseExecutor = stepExecutor.getBaseExecutor();
-      if (baseExecutor instanceof WorkflowStepExecutor) {
-        return baseExecutor.getStepExecutor(childStepName);
-      }
-      throw new Error(`${stepName} is not a workflow step`);
     }
 
     return stepExecutor;

--- a/test/scenarios/execute_steps/data.json
+++ b/test/scenarios/execute_steps/data.json
@@ -16,41 +16,9 @@
     "output": 8
   },
   {
-    "stepName": "moreOps",
-    "childStepName": "multiply",
-    "input": {
-      "a": 10,
-      "b": 2
-    },
-    "output": 20
-  },
-  {
-    "stepName": "moreOps",
-    "childStepName": "divide",
-    "input": {
-      "a": 10,
-      "b": 2
-    },
-    "output": 5
-  },
-  {
     "stepName": "invalid_step",
     "error": {
       "message": "invalid_step was not found"
-    }
-  },
-  {
-    "stepName": "add",
-    "childStepName": "not_workflow_step",
-    "error": {
-      "message": "add is not a workflow step"
-    }
-  },
-  {
-    "stepName": "moreOps",
-    "childStepName": "invalid_child_step",
-    "error": {
-      "message": "moreOps:invalid_child_step was not found"
     }
   }
 ]

--- a/test/types.ts
+++ b/test/types.ts
@@ -13,7 +13,6 @@ export type Scenario = {
   workflowPath?: string;
   options?: WorkflowOptions;
   stepName?: string;
-  childStepName?: string;
   output?: any;
   error?: ScenarioError;
   errorClass?: string;

--- a/test/utils/scenario.ts
+++ b/test/utils/scenario.ts
@@ -28,7 +28,7 @@ export class ScenarioUtils {
   static executeScenario(workflowEngine: WorkflowEngine, scenario: Scenario) {
     let executor: Executor = workflowEngine;
     if (scenario.stepName) {
-      executor = workflowEngine.getStepExecutor(scenario.stepName, scenario.childStepName);
+      executor = workflowEngine.getStepExecutor(scenario.stepName);
     }
     return this.execute(executor, scenario);
   }


### PR DESCRIPTION
## Description of the change

Reasons for removing this:
This is not used by transformer.
This restricts every step executor to extend the BaseStepExecutor, and may not be desirable all the times.
We want to add support for custom step executors so we want StepExecutor interface to be flexible.

## Checklists

### Development

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
