### PR TITLE
chore(ci): workflow cleanup (SEC-284)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,10 +59,9 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning]
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Removes npm cache from setup-node in publish workflow (the real cache-poisoning vector). Adds a zizmor ignore comment because zizmor's cache-poisoning audit models setup-node as v4+v5 union; the v5-only `package-manager-cache` input defaults to true in zizmor's model, so the finding fires on v4 even when no `cache:` is set. zizmorcore/zizmor#1488 context.

Ref: SEC-284